### PR TITLE
Removed mobile menu vertical resizing

### DIFF
--- a/website/about/documentation.html
+++ b/website/about/documentation.html
@@ -20,7 +20,7 @@
     </p>
 
     <p>
-    	The code is up on this GitHub Repo. [ETA August 18]
+    	GitHub Repo: <a href="https://github.com/DevinSmithWork/prelinger-stacks-explorer-2">https://github.com/DevinSmithWork/prelinger-stacks-explorer-2</a>
     </p>
 
 	<h2 id=toc-h2>Table of Contents</h2>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -27,7 +27,7 @@
             </div>
         </a>
 
-        <a class=main-link-a href="documentation.html">
+        <a class=main-link-a href="https://github.com/DevinSmithWork/prelinger-stacks-explorer-2">
             <div class=main-link-div>
                 GitHub Repo
             </div>

--- a/website/index.html
+++ b/website/index.html
@@ -14,7 +14,7 @@
     <!-- DUBLIN CORE -->
     <!-- https://www.dublincore.org/specifications/dublin-core/usageguide/2000-07-16/simple-html/ -->
     <link rel = "schema.DC" href = "http://purl.org/DC/elements/1.0/" />
-    <meta name = "DC.Title" content = "Prelinger Library Stacks Explorer (v2)" />
+    <meta name = "DC.Title" content = "Prelinger Library Stacks Explorer 2" />
     <meta name = "DC.Type" content = "website" />
     <meta name = "DC.Date" content = "2024-08-10" />
     <meta name = "DC.Format" content = "text/html" />
@@ -26,8 +26,8 @@
     <!-- OPEN GRAPH -->
     <!-- https://ogp.me/ -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Prelinger Library Stacks Explorer (v2)" />
-    <meta property="og:title" content="Prelinger Library Stacks Explorer (v2)" />
+    <meta property="og:site_name" content="Prelinger Library Stacks Explorer 2" />
+    <meta property="og:title" content="Prelinger Library Stacks Explorer 2" />
     <meta property="og:url" content="http://prelingerlibrary.org/stacks/v2" />
     <meta property="og:locale" content="en_US.utf-8" />
     <meta property="og:image" content="https://prelingerlibrary.org/stacks/v2-480.jpg" />
@@ -37,7 +37,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="http://prelingerlibrary.org/stacks/v2" />
     <meta name="twitter:creator" content="@devinsmithwork" />
-    <meta name="twitter:title" content="Prelinger Library Stacks Explorer (v2)" />
+    <meta name="twitter:title" content="Prelinger Library Stacks Explorer 2" />
     <meta name="twitter:description" content="An experimental browsing interface for the Prelinger library, San Francisco.">
     <meta name="twitter:image" content="https://prelingerlibrary.org/stacks/v2-480.jpg" />
 


### PR DESCRIPTION
As per usual, I found some wonky behavior on mobile just after I pushed everything to the repo. Rolling back all the functions for resizing the menu in "vertical_mode" (ie: for mobile devices)